### PR TITLE
chore(supabase): bump postgres to 17.6.1.150

### DIFF
--- a/supabase/code/docker-compose.yml
+++ b/supabase/code/docker-compose.yml
@@ -485,7 +485,7 @@ services:
 
       # Comment out everything below this point if you are using an external Postgres database
   db:
-    image: supabase/postgres:15.8.1.085
+    image: supabase/postgres:17.6.1.150
     restart: unless-stopped
     volumes:
       - ./volumes/db/realtime.sql:/docker-entrypoint-initdb.d/migrations/99-realtime.sql:Z


### PR DESCRIPTION
## What this PR does

Bumps the `db` image from `supabase/postgres:15.8.1.085` to `17.6.1.150`. One line, nothing else.

## Why

New deployments from this template currently start on Postgres 15, which reaches end of life in November 2027, while Supabase self-host has been shipping 17.x for a while. Anyone deploying today inherits a major version they will have to migrate off sooner than necessary.

## The part that needs a decision

**This is a major version bump and it is not backwards compatible for existing deployments.** A PG15 data directory will not start under 17 — the container exits on startup with a version mismatch. Anyone who redeploys after this lands, on a stack with data, breaks until they migrate.

So this only makes sense if it ships with a warning. Options, in the order I'd pick them:

1. Merge it into the next dated branch rather than an existing one, so it reaches new deployments and not running ones.
2. Merge it here with a note in the template README about the migration.
3. Leave the template on 15 and close this — perfectly reasonable, and no hard feelings.

For anyone who does want to move an existing stack, the path is a dump before switching images:

```
docker compose exec db pg_dumpall -U postgres > backup.sql
# stop the stack, remove the db volume, switch the image, start db, then:
docker compose exec -T db psql -U postgres < backup.sql
```

`pg_upgrade` also works but needs both binaries available in the same container, which this image doesn't make easy.

## Tested

Running `17.6.1.150` from this template on EasyPanel, together with #79, for ~22 hours. All 13 containers healthy. That was a fresh deployment, not an in-place upgrade — I have not tested the migration path above on a PG15 stack with data, which is exactly why I'd rather this went to new deployments only.
