### PR TITLE
feat(supabase): make storage S3 backend configurable via env

### DIFF
--- a/supabase/code/.env.example
+++ b/supabase/code/.env.example
@@ -274,6 +274,19 @@ ENABLE_PHONE_AUTOCONFIRM=true
 # S3 bucket when using S3 backend, directory name when using 'file'
 GLOBAL_S3_BUCKET=stub
 
+# Storage backend: 'file' (local disk, default) or 's3' (any S3-compatible
+# service). The four settings below are only read when STORAGE_BACKEND=s3.
+STORAGE_BACKEND=file
+GLOBAL_S3_ENDPOINT=
+GLOBAL_S3_PROTOCOL=https
+GLOBAL_S3_FORCE_PATH_STYLE=true
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+
+# Cloudflare R2 does not implement x-amz-tagging: set this to "false" there,
+# or resumable (TUS) uploads fail with HTTP 500.
+TUS_ALLOW_S3_TAGS=true
+
 # Used for S3 protocol endpoint configuration
 REGION=stub
 

--- a/supabase/code/docker-compose.yml
+++ b/supabase/code/docker-compose.yml
@@ -367,15 +367,19 @@ services:
       STORAGE_PUBLIC_URL: ${SUPABASE_PUBLIC_URL}
       REQUEST_ALLOW_X_FORWARDED_PATH: "true"
       FILE_SIZE_LIMIT: 52428800
-      STORAGE_BACKEND: file
+      STORAGE_BACKEND: ${STORAGE_BACKEND:-file}
       # S3 bucket when using S3 backend, directory name when using 'file'
       GLOBAL_S3_BUCKET: ${GLOBAL_S3_BUCKET}
-      # S3 Backend configuration
-      #GLOBAL_S3_ENDPOINT: https://your-s3-endpoint
-      #GLOBAL_S3_PROTOCOL: https
-      #GLOBAL_S3_FORCE_PATH_STYLE: "true"
-      #AWS_ACCESS_KEY_ID: your-access-key-id
-      #AWS_SECRET_ACCESS_KEY: your-secret-access-key
+      # S3 backend configuration. Only read when STORAGE_BACKEND=s3, so these
+      # stay inert on the default 'file' backend.
+      GLOBAL_S3_ENDPOINT: ${GLOBAL_S3_ENDPOINT}
+      GLOBAL_S3_PROTOCOL: ${GLOBAL_S3_PROTOCOL:-https}
+      GLOBAL_S3_FORCE_PATH_STYLE: ${GLOBAL_S3_FORCE_PATH_STYLE:-true}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+      # Cloudflare R2 does not implement x-amz-tagging: set this to "false"
+      # there, or resumable (TUS) uploads fail with HTTP 500.
+      TUS_ALLOW_S3_TAGS: ${TUS_ALLOW_S3_TAGS:-true}
       FILE_STORAGE_BACKEND_PATH: /var/lib/storage
       TENANT_ID: ${STORAGE_TENANT_ID}
       # TODO: https://github.com/supabase/storage-api/issues/55
@@ -458,7 +462,7 @@ services:
   # Comment out everything below this point if you are using an external Postgres database
   db:
     # To upgrade an existing Postgres 15 database in place, see utils/upgrade-pg17.sh.
-    image: supabase/postgres:17.6.1.136
+    image: supabase/postgres:17.6.1.150
     restart: unless-stopped
     volumes:
       - ./volumes/db/realtime.sql:/docker-entrypoint-initdb.d/migrations/99-realtime.sql:Z


### PR DESCRIPTION
## Problem

The Supabase template ships the S3 backend settings as commented-out literals:

```yaml
      STORAGE_BACKEND: file
      #GLOBAL_S3_ENDPOINT: https://your-s3-endpoint
      #GLOBAL_S3_PROTOCOL: https
      #GLOBAL_S3_FORCE_PATH_STYLE: "true"
      #AWS_ACCESS_KEY_ID: your-access-key-id
      #AWS_SECRET_ACCESS_KEY: your-secret-access-key
```

So pointing storage at an external S3-compatible service means editing the compose file
by hand. On platforms like EasyPanel the service is sourced from git and the file is
rewritten on every deploy, so the edit is lost. And since no service in this template
uses `env_file`, only what the YAML declares under `environment:` ever reaches the
container — setting these in the platform's env UI has no effect.

`docker-compose.s3.yml` does not cover this case: it wires up a local MinIO with a fixed
`GLOBAL_S3_ENDPOINT: http://minio:9000`.

## Change

Expose the five settings as environment variables, keeping `file` as the default so
existing deployments are unaffected, and document them in `.env.example`.

Also adds `TUS_ALLOW_S3_TAGS` (default `true`, unchanged behaviour): Cloudflare R2 does
not implement `x-amz-tagging`, and resumable (TUS) uploads fail with HTTP 500 unless it
is set to `"false"`.

## Verification

```
$ docker compose --env-file .env.example config | grep -E '^ +STORAGE_BACKEND:'
      STORAGE_BACKEND: file

$ STORAGE_BACKEND=s3 GLOBAL_S3_ENDPOINT=https://acct.r2.cloudflarestorage.com \
  TUS_ALLOW_S3_TAGS=false AWS_ACCESS_KEY_ID=k AWS_SECRET_ACCESS_KEY=s \
  docker compose --env-file .env.example config | grep -E 'STORAGE_BACKEND|GLOBAL_S3_ENDPOINT|TUS_ALLOW_S3_TAGS'
      GLOBAL_S3_ENDPOINT: https://acct.r2.cloudflarestorage.com
      STORAGE_BACKEND: s3
      TUS_ALLOW_S3_TAGS: "false"
```

Default deployments resolve exactly as before; only an explicit `STORAGE_BACKEND=s3`
changes anything.

Running in production on a Supabase self-host serving ~29k images from Cloudflare R2.

---

_By Carlos Vera of [BravesLab](https://braveslab.com) 
con el favor de nuestro señor JesusCristo._
