### PR TITLE
fix(supabase): add healthcheck to the meta service

### DIFF
--- a/supabase/code/docker-compose.yml
+++ b/supabase/code/docker-compose.yml
@@ -412,6 +412,17 @@ services:
       db:
         # Disable this if you are using an external Postgres database
         condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://localhost:8080/health').then((r) => {if (r.status !== 200) throw new Error(r.status)})"
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 3
     environment:
       PG_META_PORT: 8080
       PG_META_DB_HOST: ${POSTGRES_HOST}


### PR DESCRIPTION
## Problem

`meta` is the only service in the template without a healthcheck. Orchestrators that
colour a project by container health (EasyPanel, Portainer) therefore never show a
healthy stack as fully green, and a genuinely broken container is indistinguishable
from the one that simply never reports.

`postgres-meta` does declare a `HEALTHCHECK` in its own Dockerfile, but the published
images do not carry it — checked on both the version pinned here and the current
release:

```
$ docker buildx imagetools inspect supabase/postgres-meta:v0.96.6 --format '{{json .Image}}' | grep -o '"Healthcheck":[^,]*'
"Healthcheck":null
$ docker buildx imagetools inspect supabase/postgres-meta:v0.99.0 --format '{{json .Image}}' | grep -o '"Healthcheck":[^,]*'
"Healthcheck":null
```

So the compose file has to declare it.

## Change

Adds the command `postgres-meta` declares in its own Dockerfile, on the port the
template already sets (`PG_META_PORT: 8080`).

## Verification

Started `meta` v0.96.6 with `PG_META_DB_HOST` pointing at a host that does not resolve:

```
$ curl -s -o /dev/null -w '%{http_code}' http://localhost:8080/health
200
$ docker exec meta-test node -e "fetch('http://localhost:8080/health').then((r) => {if (r.status !== 200) throw new Error(r.status)})"
$ echo $?
0
```

`/health` answers 200 while the database is unreachable, so this tracks service
liveness and will not flap on a transient database blip — matching how the other
services in this file are checked.

_Desarrollado por Carlos Vera para [BravesLab](https://braveslab.com) con el favor de nuestro señor JesusCristo._